### PR TITLE
Allow user in container to use sudo

### DIFF
--- a/lib/lxdev.rb
+++ b/lib/lxdev.rb
@@ -205,6 +205,8 @@ class LxDev
     %x{sudo lxc exec #{@name} -- chmod 0700 /home/#{user}/.ssh}
     %x{ssh-add -L | sudo lxc exec #{@name} tee /home/#{user}/.ssh/authorized_keys}
     %x{sudo lxc exec #{@name} -- chown -R #{user} /home/#{user}/.ssh}
+    %x{printf "#{user} ALL=(ALL) NOPASSWD: ALL\n" | sudo lxc exec #{@name} -- tee -a /etc/sudoers}
+    %x{sudo lxc exec #{@name} -- chmod 0440 /etc/sudoers}
   end
 
   def wait_for_boot


### PR DESCRIPTION
User added to /etc/sudoers when user is created

Solves issue #1 

The Fedora image doesn't come with sudo, so this probably won't work there.. but what can you do.