### PR TITLE
Fix partial match problem with 'lxc list'

### DIFF
--- a/lib/lxdev/main.rb
+++ b/lib/lxdev/main.rb
@@ -235,7 +235,7 @@ module LxDev
 
     def get_container_status
       return @status unless @status.nil?
-      command_result = System.exec("sudo lxc list #{@name} --format=json")
+      command_result = System.exec("sudo lxc list ^#{@name}$ --format=json")
       @status = JSON.parse(command_result.output)
     end
 


### PR DESCRIPTION
lxc list could list the wrong container, assuming a container which is
running is not, and vice versa.

Do a more correct match to avoid the problem.

Resolves #29