### PR TITLE
Add a 'silent mode' for process spawning, and use it with redir

### DIFF
--- a/lib/lxdev/main.rb
+++ b/lib/lxdev/main.rb
@@ -290,7 +290,7 @@ module LxDev
       redir_pids = []
       ports.each do |guest, host|
         puts "Forwarding #{get_container_ip}:#{guest} to local port #{host}"
-        pid = System.spawn_exec("sudo redir --caddr=#{get_container_ip} --cport=#{guest} --lport=#{host}")
+        pid = System.spawn_exec("sudo redir --caddr=#{get_container_ip} --cport=#{guest} --lport=#{host}", silent: true)
         redir_pids << pid
         Process.detach(pid)
       end

--- a/lib/lxdev/system.rb
+++ b/lib/lxdev/system.rb
@@ -12,8 +12,12 @@ module LxDev
       return_object
     end
 
-    def self.spawn_exec(cmd)
-      spawn(cmd)
+    def self.spawn_exec(cmd, silent: false)
+      if silent
+        spawn(cmd, [:out, :err] => "/dev/null")
+      else
+        spawn(cmd)
+      end
     end
   end
 end


### PR DESCRIPTION
redir complains when the target port is down, which is annoying.

When using websockets, it complains incredibly much and is totally
unbearable.