### PR TITLE
Respect membership of lxd group and remove excessive sudo usage

### DIFF
--- a/bin/lxdev
+++ b/bin/lxdev
@@ -32,16 +32,15 @@ def option_parser
 Commands:
 up          Bring container up
 status      Show status of the container
-ssh         Log into the container 
+ssh         Log into the container
 halt        Stop the container
-destroy     Destroy the container 
+destroy     Destroy the container
 provision   Run provisioning commands from YAML file
 exec        Run command as root in container
 snapshot    Snapshots the container. Takes a snapshot name as parameter.
 rmsnapshot  Deletes a snapshot. Takes a snapshot name as parameter.
 restore     Restore container to a snapshot with a previous state. Takes a snapshot name as parameter.
 revert      Restore container to the last snapshot taken.
-sudoers     Create a sudoers file, allowing you to use lxdev without entering the sudo password
 EOS
   opt_parser.parse!()
 
@@ -74,8 +73,6 @@ def execute_main_command(lxdev)
     else
       lxdev.execute(command)
     end
-  when 'sudoers'
-    LxDev::Main.create_sudoers_file()
   when 'snapshot'
     snapshot_name = ARGV[1]
     if snapshot_name.nil?


### PR DESCRIPTION
This patch generally removes the need for sudo.

It is still required (and used) if the user can't or won't join the 'lxd' group, or wants to forward to a port in the range 1-1023.
